### PR TITLE
Fix credit card processing

### DIFF
--- a/src/main/java/io/dataapps/chlorine/pattern/CompositeCreditCardFinder.java
+++ b/src/main/java/io/dataapps/chlorine/pattern/CompositeCreditCardFinder.java
@@ -31,15 +31,14 @@ public class CompositeCreditCardFinder implements Finder {
 	 */
 	public CompositeCreditCardFinder () {
 		compositeFinder = new CompositeFinder("CreditCard");
-		String START_BLOCK = "([^\\d\\.-]|^)";
-		compositeFinder.add(new CreditCardFinder("Mastercard", START_BLOCK + "5[1-5][0-9]{2}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\D|$)"));
-		compositeFinder.add(new CreditCardFinder("Visa", START_BLOCK + "4[0-9]{3}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\D|$)"));
-		compositeFinder.add(new CreditCardFinder("AMEX", START_BLOCK + "(34|37)[0-9]{2}(\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{5}(\\D|$)"));
-		compositeFinder.add(new CreditCardFinder("Diners Club 1", START_BLOCK + "30[0-5][0-9](\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{4}(\\D|$)"));
-		compositeFinder.add(new CreditCardFinder("Diners Club 2", START_BLOCK + "(36|38)[0-9]{2}(\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{4}(\\D|$)"));
-		compositeFinder.add(new CreditCardFinder("Discover", START_BLOCK + "6011(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\D|$)"));
-		compositeFinder.add(new CreditCardFinder("JCB 1", START_BLOCK + "3[0-9]{3}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\D|$)"));
-		compositeFinder.add(new CreditCardFinder("JCB 2", START_BLOCK + "(2131|1800)[0-9]{11}(\\D|$)"));
+		compositeFinder.add(new CreditCardFinder("Mastercard",  "5[1-5][0-9]{2}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}"));
+		compositeFinder.add(new CreditCardFinder("Visa", "4[0-9]{3}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}"));
+		compositeFinder.add(new CreditCardFinder("AMEX", "(34|37)[0-9]{2}(\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{5}"));
+		compositeFinder.add(new CreditCardFinder("Diners Club 1", "30[0-5][0-9](\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{4}"));
+		compositeFinder.add(new CreditCardFinder("Diners Club 2", "(36|38)[0-9]{2}(\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{4}"));
+		compositeFinder.add(new CreditCardFinder("Discover", "6011(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}"));
+		compositeFinder.add(new CreditCardFinder("JCB 1", "3[0-9]{3}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}"));
+		compositeFinder.add(new CreditCardFinder("JCB 2", "(2131|1800)[0-9]{11}"));
 	}
 
 	@Override

--- a/src/main/java/io/dataapps/chlorine/pattern/CreditCardFinder.java
+++ b/src/main/java/io/dataapps/chlorine/pattern/CreditCardFinder.java
@@ -32,7 +32,7 @@ public class CreditCardFinder extends RegexFinder {
 		Matcher matcher = pattern.matcher(input);
 		while (matcher.find()) {
 
-			String match = input.substring(matcher.start()+1, matcher.end()-1);
+			String match = input.substring(matcher.start(), matcher.end());
 
 			if (postMatchCheck(match)) {
 				matches.add(match);

--- a/src/test/java/io/dataapps/chlorine/finder/TestDefaultFinders.java
+++ b/src/test/java/io/dataapps/chlorine/finder/TestDefaultFinders.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -117,6 +118,8 @@ public class TestDefaultFinders {
 	
 	private static  String multipleCreditCards =  "a"+ MASTERCARD2 + "," + AMEXCARD1 + " ";
 
+	private static  String freeTextWithCreditCards = String.format("It is my credit card number: %s please send me 156$. " +
+			"Also you can send it to this AE card %s. If you would like to use Visa please use:%s", MASTERCARD2, AMEXCARD1, VISACARD1);
 
 
 	@Test
@@ -225,5 +228,24 @@ public class TestDefaultFinders {
 		assertEquals (2, results.size());
 		assertTrue(results.contains(MASTERCARD2));
 		assertTrue(results.contains(AMEXCARD1));
+	}
+
+	@Test
+	public void testFreeTextWithCreditCards() {
+		FinderEngine engine = new FinderEngine();
+		List<String> results = engine.find(freeTextWithCreditCards).getMatches();
+		assertEquals (3, results.size());
+		assertTrue(results.contains(MASTERCARD2));
+		assertTrue(results.contains(AMEXCARD1));
+		assertTrue(results.contains(VISACARD1));
+	}
+
+	@Test
+	public void testSimpleEntry(){
+		FinderEngine engine = new FinderEngine();
+		for (String str: Arrays.asList(MASTERCARD1, MASTERCARD2, VISACARD1, VISACARD2)) {
+			List<String> results = engine.find(str).getMatches();
+			assertTrue(results.contains(str));
+		}
 	}
 }


### PR DESCRIPTION
I noticed that if credit card number is rounded by space "card 4111-1111-1111-1111 " than FinderEngine.find() method will match " 4111-1111-1111-1111 " and to resolve that issue CreditCardFinder line 35 substring was called with extra +1/-1 indexes. 
I added extra tests for case which failed for me

Please review